### PR TITLE
Add CocoaPods support

### DIFF
--- a/Source/ThirdPartyMailer.m
+++ b/Source/ThirdPartyMailer.m
@@ -29,7 +29,11 @@
 @implementation ThirdPartyMailer
 
 + (NSArray *) clients {
-    NSString *filePath = [[NSBundle mainBundle] pathForResource:@"ThirdPartyMailer" ofType:@"plist"];
+  
+	 NSBundle *bundle = [NSBundle bundleForClass:self.classForCoder];
+	 NSURL *bundleURL = [[bundle resourceURL] URLByAppendingPathComponent:@"ThirdPartyMailer.bundle"];
+	 NSBundle *resourceBundle = [NSBundle bundleWithURL:bundleURL];
+    NSString *filePath = [resourceBundle pathForResource:@"ThirdPartyMailer" ofType:@"plist"];
     NSArray *clientsMaster = [NSArray arrayWithContentsOfFile:filePath];
     NSMutableArray *list = [[NSMutableArray alloc] initWithCapacity:[clientsMaster count]];
     for (NSDictionary *clientDictionary in clientsMaster) {

--- a/ThirdPartyMailer.podspec.json
+++ b/ThirdPartyMailer.podspec.json
@@ -1,0 +1,31 @@
+{
+  "name": "ThirdPartyMailer",
+  "version": "1.3",
+  "summary": "Interact with third-party iOS mail clients, using custom URL schemes.",
+  "homepage": "https://github.com/vtourraine/ThirdPartyMailer",
+  "license": {
+	 "type": "MIT",
+	 "file": "LICENSE.md"
+  },
+  "authors": {
+	 "Vincent Tourraine": "me@vtourraine.net"
+  },
+  "social_media_url": "http://twitter.com/vtourraine",
+  "source": {
+	 "git": "https://github.com/Oggerschummer/ThirdPartyMailer.git",
+	 "tag": "1.3"
+  },
+  "source_files": ["Source/*.{h,m}"],
+  "resource_bundles": {
+	 "ThirdPartyMailer": [
+		"Source/*.{plist}"
+	 ]
+  },
+  
+  "platforms": {
+	 "ios": "8.0"
+  },
+  "frameworks": "UIKit",
+  "requires_arc": true
+
+}


### PR DESCRIPTION
This PR adds support for CocoaPods. The podfile is an adjusted version of the swift pod.
Please adjust the podfile git link and the credits to your need (currently points to my repository) and add it to the CocoaPods master repo (Maybe as "ThirdPartyMailer-Objc" ?).
Code Change: 
The plist with the supported mail clients is configured to be added into a bundle by cocoapods, so loading the file has changed a bit.
Tested in my environment, worked fine.
